### PR TITLE
Fix :Customer ID being retained in customer_ID

### DIFF
--- a/upload/admin/view/template/billing/invoice_form.tpl
+++ b/upload/admin/view/template/billing/invoice_form.tpl
@@ -268,7 +268,9 @@ $(document).ready(function () {
 	$('.date').datetimepicker({
 		format: 'YYYY-MM-DD'
 	});
-
+$("#input-customer").bind("change paste keyup", function() {
+   $('input[name=\'customer_id\']').val('');
+});
 	$('#input-customer').autocomplete({
 		'source': function (request, response) {
 			$.ajax({


### PR DESCRIPTION
When you create an invoice, and enter a customer name, the input fetches the customers in Database.
Which is then using jquery put into a hidden field "Customer_ID" in invoice form.

So in case user decides he wants to create a new customer from the form, he erases the selected customer name from customer field, but the customer_ID is retained in the hidden input field.

This can be fixed by adding the following code in the invoice_form.tpl to remove the old fetched customer ID in the customer_id input field.